### PR TITLE
Pre encode send buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ A generic module for performing simple TCP and UDP requests, for more info look 
 
 **V1.0.5**
 -Added the option to insert hex codes using the %hh format.
+
+**V1.0.6**
+-pre-encode send buffer as 'latin1' (binary) to prevent 'utf8' escape of 8bit characters

--- a/index.js
+++ b/index.js
@@ -254,29 +254,34 @@ instance.prototype.action = function(action) {
 
 	}
 
-	if (self.config.prot == 'tcp') {
+	/* 
+	 * create a binary buffer pre-encoded 'latin1' (8bit no change bytes)
+	 * sending a string assumes 'utf8' encoding 
+	 * which then escapes character values over 0x7F
+	 * and destroys the 'binary' content
+	 */
+	var sendBuf = Buffer.from(cmd + end, 'latin1');
 
-		if (cmd !== undefined) {
+	if (sendBuf != '') {
 
-			debug('sending ',cmd + end,"to",self.config.host);
+		if (self.config.prot == 'tcp') {
+
+			debug('sending ',sendBuf,"to",self.config.host);
 
 			if (self.socket !== undefined && self.socket.connected) {
-				self.socket.send(cmd + end);
+				self.socket.send(sendBuf);
 			}
 			else {
 				debug('Socket not connected :(');
 			}
 		}
-	}
 
-	if (self.config.prot == 'udp') {
-
-		if (cmd !== undefined ) {
+		if (self.config.prot == 'udp') {
 
 			if (self.udp !== undefined ) {
-				debug('sending',cmd + end,"to",self.config.host);
+				debug('sending',sendBuf,"to",self.config.host);
 
-				self.udp.send(cmd + end);
+				self.udp.send(sendBuf);
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-tcp-udp",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"api_version": "1.0.0",
 	"description": "Generic TCP and UDP",
 	"keywords": [
@@ -20,6 +20,10 @@
 		"url": "git+https://github.com/bitfocus/companion-module-generic-tcp-udp.git"
 	},
 	"author": "Andreas H. Thomsen <mc-hauge@hotmail.com>",
+	"contributors": [
+		"Andrew Broughton <andy@checkcheckonetwo.com>",
+		"John A Knight Jr <istnv@ayesti.com>"
+	],
 	"license": "MIT",
 	"bugs": {
 		"url": "https://github.com/bitfocus/companion-module-generic-tcp-udp/issues"


### PR DESCRIPTION
Pre-convert the command string to a buffer to prevent default 'utf8' conversion by the socket library.
Version bump
Should complete #1 

