### PR TITLE
Add leading '0' for odd character length Hex commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
+DEBUG-INSPECT
 /pkg
 /pkg.tgz

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ In that way, more people will get to benefit from this in the future, thanks.
 | **V2.1.1** | Indicate OK when UDP Listener is started                                                                |
 | **V2.1.2** | Use correct function to create send buffer from hex string                                              |
 | **V2.1.3** | 'concat' send buffer and end-of-message characters instead of overloaded '+'                            |
-| **V2.2.0** | Add leading '0' for single character Hex command value                                                  |
+| **V2.2.0** | Add leading '0' for odd character length Hex command value                                              |

--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ and we would therefore really appreciate if you made a module request for it her
 
 In that way, more people will get to benefit from this in the future, thanks.
 
-| Version    | Notes                                                                                                       |
-| ---------- | ----------------------------------------------------------------------------------------------------------- |
-| **V1.0.0** | A generic module for performing simple TCP and UDP requests, for more info look in HELP.md                  |
-| **V1.0.1** | Fixed errors in HELP.md file                                                                                |
-| **V1.0.2** | Added the option to chose the end caractors: \r, \n, \r\n, \n\r or none at all.                             |
-| **V1.0.5** | Added the option to insert hex codes using the %hh format.                                                  |
-| **V1.0.6** | pre-encode send buffer as 'latin1' (binary) to prevent 'utf8' escape of 8bit characters                     |
-| **V1.0.7** | re-write to ES6                                                                                             |
-| **V2.0.0** | Update for Companion 3.0                                                                                    |
+| Version    | Notes                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| **V1.0.0** | A generic module for performing simple TCP and UDP requests, for more info look in HELP.md              |
+| **V1.0.1** | Fixed errors in HELP.md file                                                                            |
+| **V1.0.2** | Added the option to chose the end caractors: \r, \n, \r\n, \n\r or none at all.                         |
+| **V1.0.5** | Added the option to insert hex codes using the %hh format.                                              |
+| **V1.0.6** | pre-encode send buffer as 'latin1' (binary) to prevent 'utf8' escape of 8bit characters                 |
+| **V1.0.7** | re-write to ES6                                                                                         |
+| **V2.0.0** | Update for Companion 3.0                                                                                |
 | **V2.1.0** | Add Send Hex action to replace deprecated `unescape` function<br>Allow host names as well as IP numbers |
+| **V2.1.1** | Indicate OK when UDP Listener is started                                                                |
+| **V2.1.2** | Use correct function to create send buffer from hex string                                              |
+| **V2.1.3** | 'concat' send buffer and end-of-message characters instead of overloaded '+'                            |
+| **V2.2.0** | Add leading '0' for single character Hex command value                                                  |

--- a/actions.js
+++ b/actions.js
@@ -16,7 +16,7 @@ export function getActionDefinitions(self) {
 					type: 'textinput',
 					id: 'id_send',
 					label: 'Command:',
-					tooltip: 'Use %hh to insert Hex codes\nObsolete, use Send HEX command instead',
+					tooltip: `Use %hh to insert Hex codes\nOBSOLETE! Use the 'Send HEX command' instead`,
 					default: '',
 					useVariables: true,
 				},
@@ -28,8 +28,8 @@ export function getActionDefinitions(self) {
 					choices: CHOICES_END,
 				},
 			],
-			callback: async (action) => {
-				const cmd = unescape(await self.parseVariablesInString(action.options.id_send))
+			callback: async (action, context) => {
+				const cmd = unescape(await context.parseVariablesInString(action.options.id_send))
 
 				if (cmd != '') {
 					/*
@@ -79,8 +79,14 @@ export function getActionDefinitions(self) {
 					choices: CHOICES_END,
 				},
 			],
-			callback: async (action) => {
-				const cmd = Buffer.from(await self.parseVariablesInString(action.options.id_send_hex), 'hex')
+			callback: async (action, context) => {
+				let cmdData = await context.parseVariablesInString(action.options.id_send_hex)
+
+				// add leading '0' if only 1 character
+				if (cmdData.length == 1) {
+					cmdData = '0' + cmdData
+				}
+				const cmd = Buffer.from(cmdData, 'hex')
 
 				if (cmd != '') {
 					/*

--- a/actions.js
+++ b/actions.js
@@ -82,8 +82,8 @@ export function getActionDefinitions(self) {
 			callback: async (action, context) => {
 				let cmdData = await context.parseVariablesInString(action.options.id_send_hex)
 
-				// add leading '0' if only 1 character
-				if (cmdData.length == 1) {
+				// add leading '0' if odd number of characters
+				if (cmdData.length % 2) {
 					cmdData = '0' + cmdData
 				}
 				const cmd = Buffer.from(cmdData, 'hex')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-tcp-udp",
-	"version": "2.1.3",
+	"version": "2.2.0",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Hex decode requires an even number of characters.
This patch adds a leading '0' if the command contains an odd number of characters.