### PR TITLE
feature add open socket on demand

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -43,10 +43,21 @@ export function getActionDefinitions(self) {
 					if (self.config.prot == 'tcp') {
 						self.log('debug', 'sending to ' + self.config.host + ': ' + sendBuf.toString())
 
-						if (self.socket !== undefined && self.socket.isConnected) {
-							self.socket.send(sendBuf)
+						if (self.config.connect_on_send) {
+							// On-demand connection mode
+							try {
+								await self.sendTcpOnDemand(sendBuf)
+								self.log('debug', 'On-demand TCP send successful')
+							} catch (err) {
+								self.log('error', 'On-demand TCP send failed: ' + err.message)
+							}
 						} else {
-							self.log('debug', 'Socket not connected :(')
+							// Traditional persistent connection mode
+							if (self.socket !== undefined && self.socket.isConnected) {
+								self.socket.send(sendBuf)
+							} else {
+								self.log('debug', 'Socket not connected :(')
+							}
 						}
 					}
 
@@ -100,10 +111,21 @@ export function getActionDefinitions(self) {
 					if (self.config.prot == 'tcp') {
 						self.log('debug', 'sending to ' + self.config.host + ': ' + sendBuf.toString('hex'))
 
-						if (self.socket !== undefined && self.socket.isConnected) {
-							self.socket.send(sendBuf)
+						if (self.config.connect_on_send) {
+							// On-demand connection mode
+							try {
+								await self.sendTcpOnDemand(sendBuf)
+								self.log('debug', 'On-demand TCP hex send successful')
+							} catch (err) {
+								self.log('error', 'On-demand TCP hex send failed: ' + err.message)
+							}
 						} else {
-							self.log('debug', 'Socket not connected :(')
+							// Traditional persistent connection mode
+							if (self.socket !== undefined && self.socket.isConnected) {
+								self.socket.send(sendBuf)
+							} else {
+								self.log('debug', 'Socket not connected :(')
+							}
 						}
 					}
 

--- a/config.js
+++ b/config.js
@@ -58,8 +58,17 @@ export const ConfigFields = [
 	},
 	{
 		type: 'checkbox',
+		id: 'connect_on_send',
+		label: 'Connect only when sending commands',
+		tooltip: 'Open TCP connection only when needed, then close immediately. Useful for proxies that close idle connections.',
+		default: false,
+		isVisible: (configValues) => configValues.prot === 'tcp',
+	},
+	{
+		type: 'checkbox',
 		id: 'saveresponse',
 		label: 'Save TCP Response',
+		tooltip: 'Save the last TCP response received. In on-demand mode, responses are captured during the 500ms connection window.',
 		default: false,
 		isVisible: (configValues) => configValues.prot === 'tcp',
 	},


### PR DESCRIPTION
## 🎯 **Feature Request Implementation**

This PR implements the feature request: **"Only open TCP socket when a command is sent"** to solve proxy compatibility issues.

### 🔍 **Problem Solved**

The user was experiencing connection state loops (OK ↔ ERROR) when using TCP through a proxy to control an Evertz router. The proxy was closing persistent connections, causing the module to constantly reconnect and fail.

### ✅ **Solution Implemented**

Added a new configuration option **"Connect only when sending commands"** that changes the TCP behavior from persistent connections to on-demand connections:

- **Before**: Persistent TCP socket that stays open and monitors connection status
- **After**: Temporary TCP socket that opens only when needed, sends command, receives response, then closes immediately

### 🔧 **Technical Changes**

#### **1. New Configuration Option**
- Added checkbox "Connect only when sending commands" in TCP configuration
- Only visible when TCP protocol is selected
- Includes helpful tooltip explaining its use for proxy scenarios

#### **2. Modified TCP Logic**
- **Traditional Mode** (unchecked): Creates persistent connection with `init_tcp()`
- **On-Demand Mode** (checked): Shows "Ready (On-demand mode)" status, no persistent connection

#### **3. New On-Demand Connection Method**
- Added `sendTcpOnDemand()` method that creates temporary TCP connections
- 5-second connection timeout for reliability
- 500ms response window to capture device responses
- Automatic connection cleanup after each command

#### **4. Updated Action Handlers**
- Modified both "Send Command" and "Send HEX Command" actions
- Automatically uses on-demand connections when the option is enabled
- Maintains backward compatibility with existing persistent connections

#### **5. Enhanced Response Handling**
- Response saving now works in both modes
- Variables are properly updated with `$(NAME:tcp_response)`
- Response format conversion (String/Hex) supported in both modes



### 📋 **Configuration Options**

When TCP is selected, users now see:
1. **Connect only when sending commands** - Enable on-demand mode
2. **Save TCP Response** - Capture device responses (works in both modes)
3. **Convert TCP Response Format** - String/Hex conversion options

### 🎉 **Benefits**

- ✅ **Eliminates connection state loops**
- ✅ **Proxy compatibility** - no persistent connections to close
- ✅ **Resource efficient** - no idle connections consuming resources
- ✅ **Reliable communication** - fresh connection for each command
- ✅ **Flexible** - users choose the mode that works for their environment
